### PR TITLE
Add web UI and enhance worker concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+index.ts.bak

--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@
 ## Repository Contents
 
 This repository provides a Cloudflare Worker script (`index.ts`) implementing the Tebi load-balancing uploader and a PicGo configuration guide (`PICGO_GUIDE.md`).
+
+## Web Front-end
+
+A lightweight HTML page is included (`frontend.html`) providing a modern interface for uploading files and viewing basic statistics. Deploy the worker and visit its root URL to access the UI. It communicates with `/upload` for uploads and `/info` for statistics.
+
+## High concurrency considerations
+
+Instead of storing account state globally, the worker randomly selects the target account for each request, avoiding contention when handling many concurrent uploads. Basic in-memory counters keep track of the number of uploads for insight during runtime.

--- a/frontend.html
+++ b/frontend.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tebi Uploader</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f5f5f5; color: #333; }
+    .container { max-width: 600px; margin: 2rem auto; background: #fff; padding: 2rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    h1 { color: #4a90e2; margin-bottom: 1rem; }
+    input[type="file"] { margin-bottom: 1rem; }
+    button { padding: 0.5rem 1rem; border: none; background: #4a90e2; color: #fff; border-radius: 4px; cursor: pointer; }
+    button:hover { background: #357ab8; }
+    #result { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Tebi Uploader</h1>
+    <form id="upload-form">
+      <input type="file" name="file" required />
+      <button type="submit">Upload</button>
+    </form>
+    <div id="result"></div>
+    <div id="stats"></div>
+  </div>
+<script>
+  async function refreshStats() {
+    const res = await fetch('/info');
+    if (res.ok) {
+      const data = await res.json();
+      document.getElementById('stats').textContent =
+        `Uploaded A: ${data.byAccountA} | Uploaded B: ${data.byAccountB} | Total: ${data.total}`;
+    }
+  }
+  document.getElementById('upload-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    const res = await fetch('/upload', { method: 'POST', body: formData });
+    const out = document.getElementById('result');
+    if (res.ok) {
+      const data = await res.json();
+      if (data.success) {
+        out.innerHTML = `<a href="${data.url}" target="_blank">${data.url}</a>`;
+      } else {
+        out.textContent = data.message;
+      }
+    } else {
+      out.textContent = 'Upload failed.';
+    }
+    await refreshStats();
+  });
+  refreshStats();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- deliver simple web front‑end to upload files and view stats
- improve the Cloudflare Worker for better concurrency by choosing the target account randomly
- expose `/info` endpoint for runtime statistics
- update README with front-end and concurrency info

## Testing
- `npm install`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_6870c36ff1dc8333a2fb6452f291df27